### PR TITLE
Return default 404 route for utils

### DIFF
--- a/src/routes/routesConsts.js
+++ b/src/routes/routesConsts.js
@@ -36,13 +36,15 @@ const menuRoutes = [
     },
 ];
 
+const notFoundRoute = {
+  id: 5,
+  name: 'Not Found',
+  path: '*',
+  Element: NotFound
+};
+
 const generalRoutes = [
-    {
-        id: 5,
-        name: 'Not Found',
-        path: '*',
-        Element: NotFound
-    }
+  notFoundRoute,
 ];
 
 const protectedRoutes = [
@@ -52,7 +54,8 @@ const initialDocumentTitle = `App Boilerplate`;
 
 export {
     menuRoutes,
+    notFoundRoute,
     generalRoutes,
     protectedRoutes,
-    initialDocumentTitle
+    initialDocumentTitle,
 };

--- a/src/routes/routesUtils.js
+++ b/src/routes/routesUtils.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { initialDocumentTitle, generalRoutes, menuRoutes, protectedRoutes } from "./routesConsts";
+import { initialDocumentTitle, generalRoutes, menuRoutes, protectedRoutes, notFoundRoute } from "./routesConsts";
 
 const getRouteById = id => {
     const menuRoute = menuRoutes.find(route => route.id === id);
@@ -10,6 +10,8 @@ const getRouteById = id => {
 
     const protectedRoute = protectedRoutes.find(route => route.id === id);
     if (!_.isEmpty(protectedRoute)) return protectedRoute;
+
+    return notFoundRoute;
 };
 
 const getRouteByPathname = pathname => {
@@ -21,6 +23,8 @@ const getRouteByPathname = pathname => {
 
     const protectedRoute = protectedRoutes.find(route => route.path === pathname);
     if (!_.isEmpty(protectedRoute)) return protectedRoute;
+
+    return notFoundRoute;
 };
 
 const buildDocumentTitle = title =>


### PR DESCRIPTION
The route utils were throwing an error for what should have been 404 routes (ex: /sdfsdfsdf) because nothing was being returned.